### PR TITLE
Add equipment stat modifiers

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -244,6 +244,54 @@ impl Unit {
             is_selected: false,
         }
     }
+
+    /// Recalculate current_stats based on base_stats and all equipped items.
+    pub fn apply_equipment(&mut self) {
+        self.current_stats = self.base_stats.clone();
+        if let Some(armor) = &self.equipment.armor {
+            self.current_stats.toughness += armor.toughness_bonus;
+            self.current_stats.agility += armor.agility_penalty;
+        }
+        // Weapons currently do not modify stats but are included for completeness.
+        if let Some(_weapon) = &self.equipment.weapon {
+            // Placeholder for future weapon stat modifiers
+        }
+    }
+
+    /// Remove all equipment modifiers, returning stats to base values.
+    pub fn remove_equipment(&mut self) {
+        self.current_stats = self.base_stats.clone();
+    }
+
+    /// Equip a new weapon and update stats accordingly.
+    pub fn equip_weapon(&mut self, weapon: Weapon) {
+        self.remove_equipment();
+        self.equipment.weapon = Some(weapon);
+        self.apply_equipment();
+    }
+
+    /// Unequip the current weapon and update stats.
+    pub fn unequip_weapon(&mut self) -> Option<Weapon> {
+        let old = self.equipment.weapon.take();
+        self.remove_equipment();
+        self.apply_equipment();
+        old
+    }
+
+    /// Equip new armor and update stats to include its bonuses.
+    pub fn equip_armor(&mut self, armor: Armor) {
+        self.remove_equipment();
+        self.equipment.armor = Some(armor);
+        self.apply_equipment();
+    }
+
+    /// Remove the current armor and revert its bonuses.
+    pub fn unequip_armor(&mut self) -> Option<Armor> {
+        let old = self.equipment.armor.take();
+        self.remove_equipment();
+        self.apply_equipment();
+        old
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/equipment.rs
+++ b/tests/equipment.rs
@@ -1,0 +1,26 @@
+use gero::models::{Unit, UnitType, Faction, Armor, ArmorTier};
+
+#[test]
+fn armor_modifiers_change_stats() {
+    let mut unit = Unit::new("u", "Unit", UnitType::Guardsman, Faction::Imperial);
+    unit.base_stats.toughness = 3;
+    unit.base_stats.agility = 4;
+    unit.apply_equipment();
+
+    let armor = Armor {
+        id: "a1".into(),
+        name: "Flak".into(),
+        tier: ArmorTier::Flak,
+        toughness_bonus: 2,
+        agility_penalty: -1,
+        special_properties: Vec::new(),
+    };
+
+    unit.equip_armor(armor.clone());
+    assert_eq!(unit.current_stats.toughness, 5);
+    assert_eq!(unit.current_stats.agility, 3);
+
+    unit.unequip_armor();
+    assert_eq!(unit.current_stats.toughness, unit.base_stats.toughness);
+    assert_eq!(unit.current_stats.agility, unit.base_stats.agility);
+}


### PR DESCRIPTION
## Summary
- update `Unit` to modify stats when equipment changes
- add equip/unequip helpers
- test armor stat modifiers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68423c7753708326afa8e8c61f1e2338