### PR TITLE
Implement ability usage system with cooldowns

### DIFF
--- a/src/combat.rs
+++ b/src/combat.rs
@@ -1,4 +1,4 @@
-use crate::models::{AnimationType, Unit, Weapon};
+use crate::models::{AnimationType, Unit, Weapon, AbilityEffect, StatsModifier};
 use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Clone)]
@@ -35,6 +35,85 @@ pub fn resolve_attack(attacker: &mut Unit, weapon: &Weapon, defender: &mut Unit,
     attacker.animation_state.current_animation = AnimationType::Attack;
 
     AttackResult { hit, damage }
+}
+
+/// Apply an ability effect to a single unit.
+fn apply_ability_effect(effect: &AbilityEffect, target: &mut Unit) {
+    if let Some(dmg) = effect.damage {
+        target.health_points -= dmg;
+    }
+    if let Some(heal) = effect.healing {
+        target.health_points += heal;
+        if target.health_points > target.current_stats.max_health {
+            target.health_points = target.current_stats.max_health;
+        }
+    }
+    if let Some(buff) = &effect.buff {
+        modify_stats(&mut target.current_stats, buff, 1);
+    }
+    if let Some(debuff) = &effect.debuff {
+        modify_stats(&mut target.current_stats, debuff, -1);
+    }
+    if let Some(status) = effect.status_applied.clone() {
+        target.status_effects.push(crate::models::StatusEffect {
+            effect_type: status,
+            remaining_turns: effect.duration.unwrap_or(1),
+            magnitude: 0,
+        });
+    }
+}
+
+fn modify_stats(stats: &mut crate::models::Stats, modifier: &StatsModifier, sign: i32) {
+    stats.strength += modifier.strength_mod * sign;
+    stats.toughness += modifier.toughness_mod * sign;
+    stats.agility += modifier.agility_mod * sign;
+    stats.intellect += modifier.intellect_mod * sign;
+    stats.willpower += modifier.willpower_mod * sign;
+    stats.fellowship += modifier.fellowship_mod * sign;
+}
+
+/// Use an ability on one or more targets.
+pub fn use_ability(
+    user: &mut Unit,
+    ability_index: usize,
+    targets: &mut [&mut Unit],
+) -> Result<(), &'static str> {
+    let ability = user
+        .abilities
+        .get_mut(ability_index)
+        .ok_or("invalid ability")?;
+
+    if user.action_points < ability.action_point_cost {
+        return Err("not enough AP");
+    }
+    if ability.current_cooldown > 0 {
+        return Err("ability on cooldown");
+    }
+
+    user.action_points -= ability.action_point_cost;
+    ability.current_cooldown = ability.cooldown;
+    user.animation_state.current_animation = ability.animation.clone();
+
+    if ability.area_of_effect.is_some() {
+        for t in targets.iter_mut() {
+            apply_ability_effect(&ability.effect, *t);
+        }
+    } else {
+        if let Some(first) = targets.get_mut(0) {
+            apply_ability_effect(&ability.effect, *first);
+        }
+    }
+
+    Ok(())
+}
+
+/// Decrement cooldowns on all of a unit's abilities.
+pub fn tick_cooldowns(unit: &mut Unit) {
+    for ability in &mut unit.abilities {
+        if ability.current_cooldown > 0 {
+            ability.current_cooldown -= 1;
+        }
+    }
 }
 
 use std::collections::VecDeque;

--- a/tests/ability.rs
+++ b/tests/ability.rs
@@ -1,0 +1,75 @@
+use gero::models::{Unit, UnitType, Faction, Ability, AbilityType, AbilityEffect, AreaOfEffect, AnimationType};
+use gero::combat::{use_ability, tick_cooldowns};
+
+#[test]
+fn single_target_ability() {
+    let mut user = Unit::new("u", "User", UnitType::Guardsman, Faction::Imperial);
+    let mut target = Unit::new("t", "Target", UnitType::OrkBoy, Faction::Ork);
+
+    user.action_points = 2;
+    user.abilities.push(Ability {
+        id: "a".into(),
+        name: "Bolt".into(),
+        ability_type: AbilityType::RangedAttack,
+        description: String::new(),
+        action_point_cost: 1,
+        cooldown: 2,
+        current_cooldown: 0,
+        range: 5,
+        area_of_effect: None,
+        effect: AbilityEffect {
+            damage: Some(3),
+            healing: None,
+            buff: None,
+            debuff: None,
+            status_applied: None,
+            duration: None,
+        },
+        animation: AnimationType::AbilityCast,
+        sound_effect_key: String::new(),
+    });
+
+    let res = use_ability(&mut user, 0, &mut [&mut target]);
+    assert!(res.is_ok());
+    assert_eq!(user.action_points, 1);
+    assert_eq!(user.abilities[0].current_cooldown, 2);
+    assert_eq!(target.health_points, target.current_stats.max_health - 3);
+
+    tick_cooldowns(&mut user);
+    assert_eq!(user.abilities[0].current_cooldown, 1);
+}
+
+#[test]
+fn aoe_hits_multiple_targets() {
+    let mut user = Unit::new("u", "User", UnitType::Guardsman, Faction::Imperial);
+    let mut t1 = Unit::new("t1", "T1", UnitType::OrkBoy, Faction::Ork);
+    let mut t2 = Unit::new("t2", "T2", UnitType::OrkBoy, Faction::Ork);
+
+    user.action_points = 2;
+    user.abilities.push(Ability {
+        id: "blast".into(),
+        name: "Blast".into(),
+        ability_type: AbilityType::RangedAttack,
+        description: String::new(),
+        action_point_cost: 1,
+        cooldown: 1,
+        current_cooldown: 0,
+        range: 5,
+        area_of_effect: Some(AreaOfEffect::Circle { radius: 1 }),
+        effect: AbilityEffect {
+            damage: Some(2),
+            healing: None,
+            buff: None,
+            debuff: None,
+            status_applied: None,
+            duration: None,
+        },
+        animation: AnimationType::AbilityCast,
+        sound_effect_key: String::new(),
+    });
+
+    let res = use_ability(&mut user, 0, &mut [&mut t1, &mut t2]);
+    assert!(res.is_ok());
+    assert_eq!(t1.health_points, t1.current_stats.max_health - 2);
+    assert_eq!(t2.health_points, t2.current_stats.max_health - 2);
+}


### PR DESCRIPTION
## Summary
- add ability usage helpers in `combat` for applying damage, healing and stat buffs
- introduce a `tick_cooldowns` helper to decrement ability cooldowns
- create unit tests for single target and AoE ability cases

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68423eef66c4832693ded68d8687eead