### PR TITLE
Add sprite loading and drawing support

### DIFF
--- a/tests/frontend_integration.rs
+++ b/tests/frontend_integration.rs
@@ -11,3 +11,20 @@ fn renderer_can_render_state() {
     renderer.render_state(&state);
     assert!(renderer.sprites.contains_key("u1"));
 }
+
+#[test]
+fn renderer_issues_draw_calls() {
+    let mut renderer = Renderer::new_headless(64, 64);
+    renderer.load_sprite_from_bytes("guard", vec![vec![0, 1], vec![2, 3]]);
+    let mut unit = Unit::new("u", "U", UnitType::Guardsman, Faction::Imperial);
+    unit.sprite_id = "guard".into();
+    unit.animation_state.frame_index = 1;
+    unit.grid_position = Position { x: 3, y: 4 };
+    let state = GameState::new(vec![unit]);
+    renderer.render_state(&state);
+    assert_eq!(renderer.draw_log.len(), 1);
+    let call = &renderer.draw_log[0];
+    assert_eq!(call.sprite_id, "guard");
+    assert_eq!(call.position, (3, 4));
+    assert_eq!(call.frame_index, 1);
+}


### PR DESCRIPTION
## Summary
- extend `Renderer` with sprite texture storage and draw logging
- record animation frame when rendering units
- support loading sprites from byte data
- test rendering behaviour with mock draw calls

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684249e430dc832687ace8180ce127af