### PR TITLE
Add input and audio subsystems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +136,24 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "bit-set"
@@ -220,6 +269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +288,17 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.8",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -332,6 +401,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce857aa0b77d77287acc1ac3e37a05a8c95a2af3647d23b15f263bdaeb7562b"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +454,12 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dispatch"
@@ -372,6 +490,21 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -427,6 +560,7 @@ name = "gero"
 version = "0.1.0"
 dependencies = [
  "pollster",
+ "rodio",
  "serde",
  "serde_json",
  "wgpu",
@@ -465,6 +599,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "glow"
@@ -516,7 +656,7 @@ dependencies = [
  "presser",
  "thiserror",
  "winapi",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -576,6 +716,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "icrate"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +740,15 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -660,6 +815,12 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -733,6 +894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +940,12 @@ dependencies = [
  "objc",
  "paste",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "naga"
@@ -820,6 +996,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -882,6 +1079,29 @@ name = "objc2-encode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "once_cell"
@@ -1054,10 +1274,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rodio"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1bb7b48ee48471f55da122c0044fcc7600cfcc85db88240b89cb832935e611"
+dependencies = [
+ "cpal",
+ "hound",
+ "symphonia",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -1253,6 +1513,55 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "symphonia"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815c942ae7ee74737bb00f965fa5b5a2ac2ce7b6c01c0cc169bbeaf7abd5f5a9"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01c2aae70f0f1fb096b6f0ff112a930b1fb3626178fba3ae68b09dce71706d4"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc622b9841a10089c5b18e99eb904f4341615d5aa55bbf4eedde1be721a4023c"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
 
 [[package]]
 name = "syn"
@@ -1765,7 +2074,17 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
  "windows-targets 0.52.6",
 ]
 
@@ -1774,6 +2093,25 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ serde_json = "1.0"
 wgpu = { version = "0.20", default-features = false, features = ["wgsl"] }
 winit = "0.29"
 pollster = "0.3"
+rodio = { version = "0.17", default-features = false, optional = true, features = ["mp3", "wav"] }
+
+[features]
+default = []
+audio = ["rodio"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Gero
+
+This crate contains the core logic for a small tactical RPG. It exposes a 
+minimal renderer, combat rules and data models. Examples below show how to set 
+up an event loop with `winit` and enable sound playback using `rodio`.
+
+```rust
+use gero::{frontend::Renderer, input::{InputHandler, GameAction}, audio::AudioSystem};
+use winit::{event::Event, event_loop::EventLoop, window::WindowBuilder};
+
+fn main() {
+    // Create window and event loop
+    let event_loop = EventLoop::new();
+    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    // Renderer and systems
+    let mut renderer = pollster::block_on(Renderer::new(&window));
+    let mut input = InputHandler::new();
+    let mut audio = AudioSystem::new();
+
+    event_loop.run(move |event, _, control| {
+        if let Some(action) = input.process_event(&event) {
+            match action {
+                GameAction::Activate => println!("activate"),
+                GameAction::SelectUp => println!("up"),
+                GameAction::SelectDown => println!("down"),
+            }
+        }
+        match event {
+            Event::WindowEvent { event: winit::event::WindowEvent::CloseRequested, .. } => *control = winit::event_loop::ControlFlow::Exit,
+            Event::MainEventsCleared => {
+                // update and render here
+                renderer.draw_log.clear();
+            }
+            _ => {}
+        }
+    });
+}
+```
+```
+
+The audio system loads raw bytes with `load_sound_from_bytes` and plays them via
+`play`. During tests a headless variant is used which simply records played
+sound keys.
+```

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+
+#[cfg(all(feature = "audio", not(test)))]
+use rodio::{OutputStream, OutputStreamHandle, Sink, Decoder, source::Source};
+use std::io::Cursor;
+
+/// Very small audio manager used for tests and demos.
+/// In production this would stream audio via `rodio`.
+pub struct AudioSystem {
+    #[cfg(all(feature = "audio", not(test)))]
+    stream: OutputStream,
+    #[cfg(all(feature = "audio", not(test)))]
+    handle: OutputStreamHandle,
+    sounds: HashMap<String, Vec<u8>>, // key -> raw audio bytes
+    /// Records which sound keys were played. Useful in tests.
+    pub played_log: Vec<String>,
+}
+
+impl AudioSystem {
+    /// Create a new audio system.
+    #[cfg(all(feature = "audio", not(test)))]
+    pub fn new() -> Self {
+        let (stream, handle) = OutputStream::try_default().expect("audio output");
+        Self { stream, handle, sounds: HashMap::new(), played_log: Vec::new() }
+    }
+
+    /// Headless constructor used without the `audio` feature or in tests.
+    #[cfg(any(test, not(feature = "audio")))]
+    pub fn new() -> Self {
+        Self { sounds: HashMap::new(), played_log: Vec::new() }
+    }
+
+    /// Load a sound from raw bytes.
+    pub fn load_sound_from_bytes(&mut self, key: &str, data: Vec<u8>) {
+        self.sounds.insert(key.to_string(), data);
+    }
+
+    /// Play a sound effect previously loaded.
+    pub fn play(&mut self, key: &str) {
+        if let Some(bytes) = self.sounds.get(key) {
+            #[cfg(all(feature = "audio", not(test)))]
+            if let Ok(decoder) = Decoder::new(Cursor::new(bytes.clone())) {
+                let sink = Sink::try_new(&self.handle).expect("sink");
+                sink.append(decoder.convert_samples());
+                sink.detach();
+            }
+        }
+        self.played_log.push(key.to_string());
+    }
+}

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -77,6 +77,7 @@ pub fn use_ability(
     user: &mut Unit,
     ability_index: usize,
     targets: &mut [&mut Unit],
+    mut audio: Option<&mut crate::audio::AudioSystem>,
 ) -> Result<(), &'static str> {
     let ability = user
         .abilities
@@ -101,6 +102,12 @@ pub fn use_ability(
     } else {
         if let Some(first) = targets.get_mut(0) {
             apply_ability_effect(&ability.effect, *first);
+        }
+    }
+
+    if let Some(sys) = audio {
+        if !ability.sound_effect_key.is_empty() {
+            sys.play(&ability.sound_effect_key);
         }
     }
 
@@ -227,7 +234,7 @@ impl CombatEncounter {
             .map(|(i, a)| (i, a.effect.damage.unwrap_or(0)))
             .max_by_key(|&(_, dmg)| dmg)
         {
-            let _ = use_ability(enemy, idx, &mut [target]);
+            let _ = use_ability(enemy, idx, &mut [target], None);
             return;
         }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,50 @@
+use winit::event::{Event, WindowEvent, DeviceEvent, ElementState, MouseButton, TouchPhase};
+use winit::keyboard::{KeyCode, PhysicalKey};
+
+/// High level actions used by the game.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GameAction {
+    SelectUp,
+    SelectDown,
+    Activate,
+}
+
+/// Maps winit events to high level [`GameAction`]s.
+/// In tests the handler records all actions that were produced.
+pub struct InputHandler {
+    pub action_log: Vec<GameAction>,
+}
+
+impl InputHandler {
+    pub fn new() -> Self {
+        Self { action_log: Vec::new() }
+    }
+
+    /// Process an event, returning an action if one was recognized.
+    pub fn process_event<T>(&mut self, event: &Event<T>) -> Option<GameAction> {
+        use GameAction::*;
+        let action = match event {
+            Event::WindowEvent { event: WindowEvent::MouseInput { state: ElementState::Pressed, button, .. }, .. } => {
+                if *button == MouseButton::Left { Some(Activate) } else { None }
+            }
+            Event::WindowEvent { event: WindowEvent::Touch(touch), .. } => {
+                if touch.phase == TouchPhase::Started { Some(Activate) } else { None }
+            }
+            Event::DeviceEvent { event: DeviceEvent::Key(raw), .. } => {
+                if raw.state == ElementState::Pressed {
+                    match raw.physical_key {
+                        PhysicalKey::Code(KeyCode::ArrowUp) => Some(SelectUp),
+                        PhysicalKey::Code(KeyCode::ArrowDown) => Some(SelectDown),
+                        PhysicalKey::Code(KeyCode::Enter) => Some(Activate),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        if let Some(ref a) = action { self.action_log.push(a.clone()); }
+        action
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,5 @@ pub mod grid;
 pub mod combat;
 pub mod state;
 pub mod frontend;
+pub mod input;
+pub mod audio;

--- a/tests/ability.rs
+++ b/tests/ability.rs
@@ -29,7 +29,7 @@ fn single_target_ability() {
         sound_effect_key: String::new(),
     });
 
-    let res = use_ability(&mut user, 0, &mut [&mut target]);
+    let res = use_ability(&mut user, 0, &mut [&mut target], None);
     assert!(res.is_ok());
     assert_eq!(user.action_points, 1);
     assert_eq!(user.abilities[0].current_cooldown, 2);
@@ -68,7 +68,7 @@ fn aoe_hits_multiple_targets() {
         sound_effect_key: String::new(),
     });
 
-    let res = use_ability(&mut user, 0, &mut [&mut t1, &mut t2]);
+    let res = use_ability(&mut user, 0, &mut [&mut t1, &mut t2], None);
     assert!(res.is_ok());
     assert_eq!(t1.health_points, t1.current_stats.max_health - 2);
     assert_eq!(t2.health_points, t2.current_stats.max_health - 2);

--- a/tests/input.rs
+++ b/tests/input.rs
@@ -1,0 +1,53 @@
+use gero::input::{InputHandler, GameAction};
+use winit::event::{Event, WindowEvent, DeviceEvent, ElementState, MouseButton, TouchPhase, Touch};
+use winit::event::DeviceId;
+use winit::keyboard::KeyCode;
+use winit::window::WindowId;
+use winit::event::RawKeyEvent;
+use winit::keyboard::PhysicalKey;
+use winit::dpi::PhysicalPosition;
+
+#[test]
+fn keyboard_event_triggers_action() {
+    let mut handler = InputHandler::new();
+    let event = Event::<()>::DeviceEvent {
+        device_id: unsafe { DeviceId::dummy() },
+        event: DeviceEvent::Key(RawKeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::ArrowUp),
+            state: ElementState::Pressed,
+        }),
+    };
+    assert_eq!(handler.process_event(&event), Some(GameAction::SelectUp));
+    assert_eq!(handler.action_log, vec![GameAction::SelectUp]);
+}
+
+#[test]
+fn mouse_event_triggers_action() {
+    let mut handler = InputHandler::new();
+    let event = Event::<()>::WindowEvent {
+        window_id: unsafe { WindowId::dummy() },
+        event: WindowEvent::MouseInput {
+            device_id: unsafe { DeviceId::dummy() },
+            state: ElementState::Pressed,
+            button: MouseButton::Left,
+        },
+    };
+    assert_eq!(handler.process_event(&event), Some(GameAction::Activate));
+}
+
+#[test]
+fn touch_event_triggers_action() {
+    let mut handler = InputHandler::new();
+    let touch = Touch {
+        device_id: unsafe { DeviceId::dummy() },
+        phase: TouchPhase::Started,
+        location: PhysicalPosition { x: 0.0, y: 0.0 },
+        force: None,
+        id: 1,
+    };
+    let event = Event::<()>::WindowEvent {
+        window_id: unsafe { WindowId::dummy() },
+        event: WindowEvent::Touch(touch),
+    };
+    assert_eq!(handler.process_event(&event), Some(GameAction::Activate));
+}


### PR DESCRIPTION
## Summary
- introduce `AudioSystem` with optional `rodio` backend
- introduce `InputHandler` translating winit events to game actions
- play ability sound effects if an `AudioSystem` is provided
- document event and sound handling in new README
- test input routing

## Testing
- `cargo test --no-run`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68424cc2b9bc8326b572bcc40c7e827f