### PR TITLE
Add new unit tests for core systems

### DIFF
--- a/tests/ability_effects.rs
+++ b/tests/ability_effects.rs
@@ -1,0 +1,76 @@
+use gero::models::{Unit, UnitType, Faction, Ability, AbilityType, AbilityEffect, AnimationType, StatsModifier, EffectType};
+use gero::combat::use_ability;
+
+fn make_heal_buff_ability() -> Ability {
+    Ability {
+        id: "heal".into(),
+        name: "Heal".into(),
+        ability_type: AbilityType::Healing,
+        description: String::new(),
+        action_point_cost: 1,
+        cooldown: 0,
+        current_cooldown: 0,
+        range: 5,
+        area_of_effect: None,
+        effect: AbilityEffect {
+            damage: None,
+            healing: Some(3),
+            buff: Some(StatsModifier { strength_mod: 1, toughness_mod: 0, agility_mod: 0, intellect_mod: 0, willpower_mod: 0, fellowship_mod: 0 }),
+            debuff: None,
+            status_applied: None,
+            duration: None,
+        },
+        animation: AnimationType::AbilityCast,
+        sound_effect_key: String::new(),
+    }
+}
+
+fn make_status_ability() -> Ability {
+    Ability {
+        id: "poison".into(),
+        name: "Poison".into(),
+        ability_type: AbilityType::RangedAttack,
+        description: String::new(),
+        action_point_cost: 1,
+        cooldown: 0,
+        current_cooldown: 0,
+        range: 5,
+        area_of_effect: None,
+        effect: AbilityEffect {
+            damage: None,
+            healing: None,
+            buff: None,
+            debuff: None,
+            status_applied: Some(EffectType::Poison),
+            duration: Some(2),
+        },
+        animation: AnimationType::AbilityCast,
+        sound_effect_key: String::new(),
+    }
+}
+
+#[test]
+fn heal_and_buff_increases_stats() {
+    let mut user = Unit::new("u", "User", UnitType::Guardsman, Faction::Imperial);
+    let mut target = Unit::new("t", "Target", UnitType::Guardsman, Faction::Imperial);
+    target.health_points = 5;
+    user.action_points = 2;
+    user.abilities.push(make_heal_buff_ability());
+    let _ = use_ability(&mut user, 0, &mut [&mut target], None).unwrap();
+    assert_eq!(target.health_points, 8);
+    assert_eq!(target.current_stats.strength, target.base_stats.strength + 1);
+}
+
+#[test]
+fn applying_status_effect_adds_to_unit() {
+    let mut user = Unit::new("u", "User", UnitType::Guardsman, Faction::Imperial);
+    let mut target = Unit::new("t", "Target", UnitType::Guardsman, Faction::Imperial);
+    user.action_points = 2;
+    user.abilities.push(make_status_ability());
+    assert!(target.status_effects.is_empty());
+    let _ = use_ability(&mut user, 0, &mut [&mut target], None).unwrap();
+    assert_eq!(target.status_effects.len(), 1);
+    let se = &target.status_effects[0];
+    assert!(matches!(se.effect_type, EffectType::Poison));
+    assert_eq!(se.remaining_turns, 2);
+}

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,0 +1,16 @@
+use gero::audio::AudioSystem;
+
+#[test]
+fn load_and_play_records_sound() {
+    let mut audio = AudioSystem::new();
+    audio.load_sound_from_bytes("beep", vec![1, 2, 3]);
+    audio.play("beep");
+    assert_eq!(audio.played_log, vec!["beep"]);
+}
+
+#[test]
+fn playing_unloaded_sound_is_logged() {
+    let mut audio = AudioSystem::new();
+    audio.play("missing");
+    assert_eq!(audio.played_log, vec!["missing"]);
+}

--- a/tests/combat_resolution.rs
+++ b/tests/combat_resolution.rs
@@ -1,0 +1,46 @@
+use gero::models::{Unit, UnitType, Faction, Weapon, WeaponTier};
+use gero::combat::resolve_attack;
+
+fn setup_units() -> (Unit, Unit, Weapon) {
+    let mut attacker = Unit::new("a", "Attacker", UnitType::Guardsman, Faction::Imperial);
+    attacker.current_stats.agility = 3;
+    attacker.current_stats.strength = 2;
+    let mut defender = Unit::new("d", "Defender", UnitType::OrkBoy, Faction::Ork);
+    defender.current_stats.toughness = 2;
+    let weapon = Weapon {
+        id: "w".into(),
+        name: "Rifle".into(),
+        tier: WeaponTier::Basic,
+        damage: 3,
+        accuracy: 0.5,
+        range: 5,
+        armor_piercing: None,
+        action_point_cost: 1,
+        critical_chance: 0.0,
+        abilities_granted: Vec::new(),
+    };
+    (attacker, defender, weapon)
+}
+
+#[test]
+fn attack_misses_with_low_hit_chance() {
+    let (mut a, mut d, w) = setup_units();
+    // High roll so it should miss
+    let res = resolve_attack(&mut a, &w, &mut d, 99, 0);
+    assert!(!res.hit);
+    assert_eq!(res.damage, 0);
+    // action points spent even on miss
+    assert_eq!(a.action_points, a.current_stats.max_action - w.action_point_cost);
+}
+
+#[test]
+fn critical_hit_doubles_damage() {
+    let (mut a, mut d, mut w) = setup_units();
+    w.damage = 2;
+    let starting_hp = d.health_points;
+    // roll <=10 triggers critical
+    let res = resolve_attack(&mut a, &w, &mut d, 5, 0);
+    assert!(res.hit);
+    assert_eq!(d.health_points, starting_hp - res.damage);
+    assert!(res.damage > w.damage); // should be doubled
+}

--- a/tests/movement.rs
+++ b/tests/movement.rs
@@ -1,0 +1,23 @@
+use gero::models::{Unit, UnitType, Faction, Position};
+use gero::grid::{GridMap, TerrainType, try_move};
+
+#[test]
+fn hazardous_tile_applies_damage() {
+    let mut unit = Unit::new("u", "U", UnitType::Guardsman, Faction::Imperial);
+    unit.current_stats.agility = 10; // 5 MP
+    let mut map = GridMap::new(3, 1);
+    map.set_terrain(&Position { x: 2, y: 0 }, TerrainType::Hazardous);
+    let start_hp = unit.health_points;
+    assert!(try_move(&mut unit, Position { x: 2, y: 0 }, &map));
+    assert_eq!(unit.grid_position, Position { x: 2, y: 0 });
+    assert_eq!(unit.health_points, start_hp - 1);
+}
+
+#[test]
+fn move_out_of_bounds_fails() {
+    let mut unit = Unit::new("u", "U", UnitType::Guardsman, Faction::Imperial);
+    unit.current_stats.agility = 4;
+    let map = GridMap::new(2, 2);
+    assert!(!try_move(&mut unit, Position { x: 2, y: 2 }, &map));
+    assert_eq!(unit.grid_position, Position { x: 0, y: 0 });
+}

--- a/tests/state_serialization.rs
+++ b/tests/state_serialization.rs
@@ -1,0 +1,14 @@
+use gero::models::{Unit, UnitType, Faction, StatusEffect, EffectType};
+use gero::state::GameState;
+
+#[test]
+fn status_effects_persist_through_save() {
+    let mut unit = Unit::new("u", "Unit", UnitType::Guardsman, Faction::Imperial);
+    unit.status_effects.push(StatusEffect { effect_type: EffectType::Stun, remaining_turns: 2, magnitude: 0 });
+    let state = GameState::new(vec![unit.clone()]);
+    let data = state.save_to_string();
+    let loaded = GameState::load_from_str(&data);
+    assert_eq!(loaded.units[0].status_effects.len(), 1);
+    assert!(matches!(loaded.units[0].status_effects[0].effect_type, EffectType::Stun));
+    assert_eq!(loaded.units[0].status_effects[0].remaining_turns, 2);
+}


### PR DESCRIPTION
## Summary
- add combat resolution tests including miss and critical hit cases
- cover ability effects like healing, buffs, and status application
- test movement edge cases and audio logging
- verify status effects persist through save/load

## Testing
- `cargo test`
- `cargo tarpaulin --out Xml --output-dir tarpaulin-output`

------
https://chatgpt.com/codex/tasks/task_e_684251dec0a0832687ff46cbf0882c05