### PR TITLE
Add weapon equipment test

### DIFF
--- a/tests/equipment.rs
+++ b/tests/equipment.rs
@@ -1,4 +1,4 @@
-use gero::models::{Unit, UnitType, Faction, Armor, ArmorTier};
+use gero::models::{Unit, UnitType, Faction, Armor, ArmorTier, Weapon, WeaponTier};
 
 #[test]
 fn armor_modifiers_change_stats() {
@@ -23,4 +23,57 @@ fn armor_modifiers_change_stats() {
     unit.unequip_armor();
     assert_eq!(unit.current_stats.toughness, unit.base_stats.toughness);
     assert_eq!(unit.current_stats.agility, unit.base_stats.agility);
+}
+
+#[test]
+fn weapon_equipment_pipeline_keeps_stats_unchanged() {
+    let mut unit = Unit::new("u", "Unit", UnitType::Guardsman, Faction::Imperial);
+    unit.base_stats.strength = 2;
+    unit.base_stats.agility = 3;
+    unit.apply_equipment();
+
+    let weapon = Weapon {
+        id: "w1".into(),
+        name: "Lasgun".into(),
+        tier: WeaponTier::Basic,
+        damage: 2,
+        accuracy: 1.0,
+        range: 5,
+        armor_piercing: None,
+        action_point_cost: 1,
+        critical_chance: 0.0,
+        abilities_granted: Vec::new(),
+    };
+
+    let base = unit.base_stats.clone();
+    unit.equip_weapon(weapon.clone());
+    assert_eq!(unit.current_stats.strength, base.strength);
+    assert_eq!(unit.current_stats.toughness, base.toughness);
+    assert_eq!(unit.current_stats.agility, base.agility);
+    assert_eq!(unit.current_stats.intellect, base.intellect);
+    assert_eq!(unit.current_stats.willpower, base.willpower);
+    assert_eq!(unit.current_stats.fellowship, base.fellowship);
+    assert_eq!(unit.current_stats.max_health, base.max_health);
+    assert_eq!(unit.current_stats.max_action, base.max_action);
+
+    let returned = unit.unequip_weapon().expect("weapon returned");
+    assert_eq!(returned.id, weapon.id);
+    assert_eq!(returned.name, weapon.name);
+    assert!(matches!(returned.tier, WeaponTier::Basic));
+    assert_eq!(returned.damage, weapon.damage);
+    assert_eq!(returned.accuracy, weapon.accuracy);
+    assert_eq!(returned.range, weapon.range);
+    assert_eq!(returned.armor_piercing, weapon.armor_piercing);
+    assert_eq!(returned.action_point_cost, weapon.action_point_cost);
+    assert_eq!(returned.critical_chance, weapon.critical_chance);
+    assert_eq!(returned.abilities_granted.len(), weapon.abilities_granted.len());
+
+    assert_eq!(unit.current_stats.strength, base.strength);
+    assert_eq!(unit.current_stats.toughness, base.toughness);
+    assert_eq!(unit.current_stats.agility, base.agility);
+    assert_eq!(unit.current_stats.intellect, base.intellect);
+    assert_eq!(unit.current_stats.willpower, base.willpower);
+    assert_eq!(unit.current_stats.fellowship, base.fellowship);
+    assert_eq!(unit.current_stats.max_health, base.max_health);
+    assert_eq!(unit.current_stats.max_action, base.max_action);
 }


### PR DESCRIPTION
## Summary
- extend equipment tests to verify weapon pipeline

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684342e9b95c8326b40e8403ca033c4c