### PR TITLE
Implement localization and accessibility modules

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -1,0 +1,10 @@
+{
+    "ui.tab.abilities": "Abilities",
+    "ui.tab.inventory": "Inventory",
+    "panel.top_bar": "panel:top_bar",
+    "panel.battlefield": "panel:battlefield",
+    "panel.info_panel": "panel:info_panel",
+    "panel.bottom_bar": "panel:bottom_bar",
+    "float.heal": "float:heal",
+    "float.damage": "float:damage"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod frontend;
 pub mod input;
 pub mod audio;
 pub mod ui;
+pub mod localization;

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+use std::fs;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct LanguageFile(HashMap<String, String>);
+
+#[derive(Debug)]
+pub struct Localizer {
+    translations: HashMap<String, String>,
+}
+
+impl Localizer {
+    pub fn new(language: &str) -> std::io::Result<Self> {
+        let mut loc = Localizer { translations: HashMap::new() };
+        loc.load(language)?;
+        Ok(loc)
+    }
+
+    pub fn load(&mut self, language: &str) -> std::io::Result<()> {
+        let path = format!("assets/locales/{}.json", language);
+        let data = fs::read_to_string(path)?;
+        let map: HashMap<String, String> = serde_json::from_str(&data).unwrap_or_default();
+        self.translations = map;
+        Ok(())
+    }
+
+    pub fn get(&self, key: &str) -> String {
+        self.translations
+            .get(key)
+            .cloned()
+            .unwrap_or_else(|| key.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_language_file() {
+        let loc = Localizer::new("en").unwrap();
+        assert_eq!(loc.get("ui.tab.abilities"), "Abilities");
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,8 @@
 use crate::frontend::{Renderer, DrawCall};
 use crate::input::GameAction;
+use crate::localization::Localizer;
+
+pub mod options;
 
 #[derive(Debug, Clone)]
 pub struct Panel {
@@ -26,6 +29,15 @@ pub struct FloatingText {
 pub enum UiTab {
     Abilities,
     Inventory,
+}
+
+impl UiTab {
+    pub fn label(&self, loc: &Localizer) -> String {
+        match self {
+            UiTab::Abilities => loc.get("ui.tab.abilities"),
+            UiTab::Inventory => loc.get("ui.tab.inventory"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -127,11 +139,11 @@ impl UiManager {
         self.floating_texts.push(FloatingText { value, position, is_heal: value > 0 });
     }
 
-    pub fn render(&mut self, renderer: &mut Renderer) {
-        renderer.draw_log.push(DrawCall { sprite_id: "panel:top_bar".into(), position: (self.top_bar.x, self.top_bar.y), frame_index: 0 });
-        renderer.draw_log.push(DrawCall { sprite_id: "panel:battlefield".into(), position: (self.battlefield.x, self.battlefield.y), frame_index: 0 });
-        renderer.draw_log.push(DrawCall { sprite_id: "panel:info_panel".into(), position: (self.info_panel.x, self.info_panel.y), frame_index: 0 });
-        renderer.draw_log.push(DrawCall { sprite_id: "panel:bottom_bar".into(), position: (self.bottom_bar.x, self.bottom_bar.y), frame_index: 0 });
+    pub fn render(&mut self, renderer: &mut Renderer, loc: &Localizer) {
+        renderer.draw_log.push(DrawCall { sprite_id: loc.get("panel.top_bar"), position: (self.top_bar.x, self.top_bar.y), frame_index: 0 });
+        renderer.draw_log.push(DrawCall { sprite_id: loc.get("panel.battlefield"), position: (self.battlefield.x, self.battlefield.y), frame_index: 0 });
+        renderer.draw_log.push(DrawCall { sprite_id: loc.get("panel.info_panel"), position: (self.info_panel.x, self.info_panel.y), frame_index: 0 });
+        renderer.draw_log.push(DrawCall { sprite_id: loc.get("panel.bottom_bar"), position: (self.bottom_bar.x, self.bottom_bar.y), frame_index: 0 });
 
         for btn in &self.ability_buttons {
             renderer.draw_log.push(DrawCall { sprite_id: format!("button:ability:{}", btn.id), position: (btn.bounds.x, btn.bounds.y), frame_index: 0 });
@@ -141,8 +153,9 @@ impl UiManager {
         }
 
         for ft in &self.floating_texts {
-            let kind = if ft.is_heal { "heal" } else { "damage" };
-            renderer.draw_log.push(DrawCall { sprite_id: format!("float:{}:{}", kind, ft.value.abs()), position: ft.position, frame_index: 0 });
+            let kind_key = if ft.is_heal { "float.heal" } else { "float.damage" };
+            let prefix = loc.get(kind_key);
+            renderer.draw_log.push(DrawCall { sprite_id: format!("{}:{}", prefix, ft.value.abs()), position: ft.position, frame_index: 0 });
         }
     }
 }

--- a/src/ui/options.rs
+++ b/src/ui/options.rs
@@ -1,0 +1,31 @@
+#[derive(Debug, Clone)]
+pub enum ColorBlindPalette {
+    Normal,
+    Protanopia,
+    Deuteranopia,
+    Tritanopia,
+}
+
+#[derive(Debug, Clone)]
+pub struct AccessibilitySettings {
+    pub palette: ColorBlindPalette,
+    pub font_scale: f32,
+    pub subtitles: bool,
+}
+
+impl Default for AccessibilitySettings {
+    fn default() -> Self {
+        Self { palette: ColorBlindPalette::Normal, font_scale: 1.0, subtitles: false }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OptionsMenu {
+    pub accessibility: AccessibilitySettings,
+}
+
+impl OptionsMenu {
+    pub fn new() -> Self {
+        Self { accessibility: AccessibilitySettings::default() }
+    }
+}

--- a/tests/localization.rs
+++ b/tests/localization.rs
@@ -1,0 +1,20 @@
+use gero::localization::Localizer;
+use gero::ui::{UiManager, UiTab};
+use gero::frontend::Renderer;
+
+#[test]
+fn localizer_loads_file_and_returns_value() {
+    let loc = Localizer::new("en").unwrap();
+    assert_eq!(loc.get("ui.tab.abilities"), "Abilities");
+}
+
+#[test]
+fn ui_render_uses_localized_strings() {
+    let mut ui = UiManager::new(50, 50, vec![], vec![]);
+    ui.spawn_floating_text(-3, (1, 1));
+    let mut renderer = Renderer::new_headless(50, 50);
+    let loc = Localizer::new("en").unwrap();
+    ui.render(&mut renderer, &loc);
+    assert!(renderer.draw_log.iter().any(|c| c.sprite_id == "float:damage:3"));
+    assert_eq!(UiTab::Abilities.label(&loc), "Abilities");
+}

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,4 +1,5 @@
 use gero::ui::{UiManager, UiTab, UiEvent};
+use gero::localization::Localizer;
 use gero::frontend::Renderer;
 use gero::input::{InputHandler, GameAction};
 use winit::event::{Event, DeviceEvent, WindowEvent, ElementState, MouseButton};
@@ -37,7 +38,8 @@ fn floating_text_draws_using_renderer() {
     let mut ui = UiManager::new(50, 50, vec![], vec![]);
     ui.spawn_floating_text(-5, (10, 10));
     let mut renderer = Renderer::new_headless(50, 50);
-    ui.render(&mut renderer);
+    let loc = Localizer::new("en").unwrap();
+    ui.render(&mut renderer, &loc);
     assert!(renderer
         .draw_log
         .iter()


### PR DESCRIPTION
## Summary
- add a simple `Localizer` to load translations from `assets/locales/*.json`
- expose new `localization` module in the library
- integrate `Localizer` into UI and provide labels for tabs and floating text
- add accessibility structures for options menu
- update UI tests and add new tests covering localization

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684728a9dfcc832695066a51c2114961